### PR TITLE
added maven central link to be unavailble for pido-russians

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [Portage](https://wiki.gentoo.org/wiki/Project:Portage)
 - [NuGet](https://www.nuget.org/)
 - [hexpm](https://hex.pm/)
+- [maven central](https://mvnrepository.com/repos/central)
 
 ### Version controls
 - [Github](https://github.com/)
@@ -150,6 +151,7 @@
 - [Portage](https://wiki.gentoo.org/wiki/Project:Portage)
 - [NuGet](https://www.nuget.org/)
 - [hexpm](https://hex.pm/)
+- [maven central](https://mvnrepository.com/repos/central)
 
 ### Контроль версій
 - [Github](https://github.com/)


### PR DESCRIPTION
### Purpose
to block access to the largest package distributor in java world