### PR TITLE
Engineering, Construction and Modeling software

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,80 @@
    </tbody>
 </table>
 
+### Engineering, Construction and Modeling software
+<table>
+   <thead>
+      <tr>
+         <th>Name</th>
+         <th>CEO Twitter</th>
+         <th>CEO Linkedin</th>
+         <th>Vote</th>
+         <th align="center">
+            With 
+            <g-emoji class="g-emoji" alias="ukraine" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f1fa-1f1e6.png">🇺🇦</g-emoji>
+         </th>
+      </tr>
+   </thead>
+   <tbody>
+      <tr>
+         <td><a href="https://www.autodesk.com/" rel="nofollow">Autodesk</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.nemetschek.com/" rel="nofollow">Nemetschek</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.trimble.com/" rel="nofollow">Trimble</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.mathworks.com/" rel="nofollow">MathWorks</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.3ds.com/" rel="nofollow">Dassault Systèmes</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="http://www.cadence.com/" rel="nofollow">Cadence Design Systems</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="http://www.altera.com/" rel="nofollow">Altera</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="http://www.altium.com/" rel="nofollow">Altium</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+   </tbody>
+</table>
+
 ### Companies, Software, Activations
 
 - **[Oracle](https://twitter.com/Oracle/status/1499058658583490568?s=20&t=UqZt3qE7gEzDj_KPLi1v6Q)** 🇺🇦
@@ -685,6 +759,11 @@
 
 - **[Zoom](https://zoom.us/)**
     - Blocking access for communication
+
+- **[Autodesk](https://www.autodesk.com/)**
+    - Revocation of product activation
+    - Blocking access to cloud based products
+    - Closing of official representative offices in Russia
 
 ### Cloud Providers
 <table>

--- a/ru/README.md
+++ b/ru/README.md
@@ -661,8 +661,84 @@
    </tbody>
 </table>
 
+### ПО для проектирования, строительства и моделирования
+<table>
+   <thead>
+      <tr>
+         <th>Имя</th>
+         <th>CEO Twitter</th>
+         <th>CEO Linkedin</th>
+         <th>Голосование</th>
+         <th align="center">
+            Вместе с 
+            <g-emoji class="g-emoji" alias="ukraine" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f1fa-1f1e6.png">🇺🇦</g-emoji>
+         </th>
+      </tr>
+   </thead>
+   <tbody>
+      <tr>
+         <td><a href="https://www.autodesk.com/" rel="nofollow">Autodesk</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.nemetschek.com/" rel="nofollow">Nemetschek</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.trimble.com/" rel="nofollow">Trimble</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.mathworks.com/" rel="nofollow">MathWorks</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.3ds.com/" rel="nofollow">Dassault Systèmes</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="http://www.cadence.com/" rel="nofollow">Cadence Design Systems</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="http://www.altera.com/" rel="nofollow">Altera</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="http://www.altium.com/" rel="nofollow">Altium</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+   </tbody>
+</table>
+
 ### Компании, Программное обеспечение, Активации
+
 - **[Oracle](https://twitter.com/Oracle/status/1499058658583490568?s=20&t=UqZt3qE7gEzDj_KPLi1v6Q)** 🇺🇦
+
 - **[Microsoft](https://www.microsoft.com/)**
     - Отзыв активации продуктов
     - Visual Studio Code запрет на свободное скачивание
@@ -684,6 +760,11 @@
 
 - **[Zoom](https://zoom.us/)**
     - Блокировка доступа для общения
+
+- **[Autodesk](https://www.autodesk.com/)**
+    - Отзыв активации продукта
+    - Блокировка доступа к облачным продуктам
+    - Закрытие официальных представительств в России
 
 ### Облачные провайдеры
 <table>

--- a/uk/README.md
+++ b/uk/README.md
@@ -659,7 +659,82 @@
    </tbody>
 </table>
 
+### ПЗ для інженерії, будівництва та моделювання
+<table>
+   <thead>
+      <tr>
+         <th>Ім'я</th>
+         <th>CEO Twitter</th>
+         <th>CEO Linkedin</th>
+         <th>Голосування</th>
+         <th align="center">
+            Разом з 
+            <g-emoji class="g-emoji" alias="ukraine" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/1f1fa-1f1e6.png">🇺🇦</g-emoji>
+         </th>
+      </tr>
+   </thead>
+   <tbody>
+      <tr>
+         <td><a href="https://www.autodesk.com/" rel="nofollow">Autodesk</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.nemetschek.com/" rel="nofollow">Nemetschek</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.trimble.com/" rel="nofollow">Trimble</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.mathworks.com/" rel="nofollow">MathWorks</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="https://www.3ds.com/" rel="nofollow">Dassault Systèmes</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="http://www.cadence.com/" rel="nofollow">Cadence Design Systems</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="http://www.altera.com/" rel="nofollow">Altera</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+      <tr>
+         <td><a href="http://www.altium.com/" rel="nofollow">Altium</a></td>
+         <td></td>
+         <td></td>
+         <td></td>
+         <td align="center"></td>
+      </tr>
+   </tbody>
+</table>
+
 ### Компанії, Програмне забезпечення, Активації
+
 - **[Oracle](https://twitter.com/Oracle/status/1499058658583490568?s=20&t=UqZt3qE7gEzDj_KPLi1v6Q)** 🇺🇦
 
 - **[Microsoft](https://www.microsoft.com/)**
@@ -683,6 +758,11 @@
 
 - **[Zoom](https://zoom.us/)**
     - Блокування доступу для спілкування
+
+- **[Autodesk](https://www.autodesk.com/)**
+    - Відкликання активації продуктів
+    - Блокування доступу до хмарних продуктів
+    - Закриття офіційних представництв у Росії
 
 ### Хмарні провайдери
 <table>


### PR DESCRIPTION
**I am creating this pull request at the request of my colleagues from Kharkiv who are now hiding in the subway from the Russian bombing.**

Ukraine has a very strong community of engineers. These are interior designers, architects, modelers, industrial designers, developers of integrated circuits and electronic devices.
Now the work of every professional in this field is tied to modern programs. Therefore, we consider ourselves part of the Ukrainian IT community, and we want to join this open letter!

We believe that the following companies should limit access to their products in Russia. These software are used for engineering, construction, and modeling usually for civil purposes. But it can be used by Russian law enforcement agencies and the army to **build military facilities, design missiles and other weapons**, microchips and printed circuit boards for them, and so on.

More details about each company:

**Autodesk** is one of the leading manufacturers of software for industry and design. This is a kind of Adobe in the field of design. More details about their software can be found at: https://www.youtube.com/watch?v=g3d33AjzA-8

**Nemetschek** - the main software I came across: Allplan, ArchiCAD, Bluebeam Revu (these are programs for BIM-design, and viewing and working with drawings). The company also produces much other software for the industry.

**Trimble** - develops software and devices for surveying.

**MathWorks** - Matlab, Simulink, Stateflow - calculations and process simulations.

**Dassault Systèmes** - CATIA, SolidWorks - well-known packages for simulation and calculation of engineering products.

**Cadence Design Systems**, **Altera** - their packages are used to develop and model integrated circuits.

**Altium** - design of electronic devices, the layout of printed circuit boards, etc.

If you add this part to the open letter - I will update it in the future.

---

Створюю цей pull request за проханням моїх колег з Харкова які зараз ховаються у метро від Російських бомбардувань.

В Україні дуже потужне ком'юніті інженерів. Це дизайнери інтер'єрів, архітектори, моделювальники, промислові конструктори, розробники інтегральних схем та .
Зараз робота кожного професіонала у цій сфері зав'язана на сучасні програми. Томи ми вважаємо себе частиною Української IT-спільноти, та бажаємо приєднатись до цього відкритого листа!

Ми вважаємо що наступні компанії мають обмежити доступ до своїх продуктів у Росії. Це ПЗ використовуються для інженерії, будівництва та моделювання зазвичай для цивільних потреб. Але може бути використане російськими силовими структурами для побудови військових об'єктів, проєктування ракет та іншого озброєння, мікрочіпів та друкованих плат для них, тощо.

Більш детально про кожну компанію: 

Autodesk - один з головних виробників ПЗ для промисловості та проектування. Це своєрідний Adobe у сфері проєктування. Більш детально про їх софт можна подивитись за посиланням: https://www.youtube.com/watch?v=g3d33AjzA-8

Nemetschek - основний софт з яким я стикався: Allplan, ArchiCAD, Bluebeam Revu (це програми для BIM-проектування, та перегляду й роботи з кресленнями). Також ця компанія випускає безліч іншого софту для промисловості.

Trimble - розробляє софт та пристрої для геодезичних робіт.

MathWorks - Matlab, Simulink, Stateflow - розрахунки та симуляції процесів.

Dassault Systèmes - CATIA, SolidWorks - відомі пакети для симуляції та розрахунків інженерних виробів.

Cadence Design Systems, Altera - їх пакети використовуються для розробки та моделювання інтегральних схем.

Altium - проектування електронних пристроїв, розводка друкованих плат, тощо.


